### PR TITLE
retains 2.10 release of version 0.3.0, while adding necessary changes to

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,18 @@ import Dependencies._
 lazy val chart = (
   ChartProject("scala-chart", ".")
   settings (
-    libraryDependencies ++= Seq(swing % scalaVersion.value, jfreechart, specs2 % "test"),
+    libraryDependencies ++= {
+      val sv = scalaVersion.value
+      val swingDep = if (sv startsWith "2.10")
+        "org.scala-lang" % "scala-swing" % sv
+      else
+        "org.scala-lang.modules" %% "scala-swing" % "1.0.1"
+      val specsDep = if (sv startsWith "2.10")
+        specs2 % "2.2.3"
+      else
+        specs2 % "2.3.10"
+      Seq(swingDep, jfreechart, specsDep % "test")
+    },
     scalacOptions in (Compile, doc) <++= (baseDirectory) map { bd =>
       Seq("-sourcepath", bd.getAbsolutePath, "-doc-source-url", docURL)
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.1

--- a/project/build.scala
+++ b/project/build.scala
@@ -8,10 +8,11 @@ package object build {
     organization := "com.github.wookietreiber",
     version      := "0.3.0",
     scalaVersion := "2.10.3",
+    crossScalaVersions := Seq("2.11.0-RC3", "2.10.4"),
     initialCommands in Compile in console += """
-      import scalax.chart._
-      import scalax.chart.Charting._
-    """
+      |import scalax.chart._
+      |import scalax.chart.Charting._
+      |""".stripMargin
   )
 
   val docURL = "https://github.com/wookietreiber/scala-chart/tree/develop€{FILE_PATH}.scala"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -4,7 +4,6 @@ package build
 import sbt._
 
 object Dependencies {
-  val jfreechart = "org.jfree"      %  "jfreechart"  % "1.0.15"
-  val specs2     = "org.specs2"     %% "specs2"      % "2.2.3"
-  val swing      = "org.scala-lang" %  "scala-swing"
+  val jfreechart = "org.jfree"  %  "jfreechart"  % "1.0.15"
+  val specs2     = "org.specs2" %% "specs2"
 }


### PR DESCRIPTION
compile and publish with Scala 2.11.0-RC3. now from master :)

this is so that one can test stable 0.3.0 with current RC and eventually 2.11.0 final.
