### PR TITLE
Update Scala version to 2.12.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,23 @@ branches:
     - develop
 
 scala:
+  - "2.12.0"
   - "2.11.8"
   - "2.10.6"
 
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6
+
+matrix:
+  exclude:
+  - scala: "2.12.0"
+    jdk: oraclejdk7
+  - scala: "2.12.0"
+    jdk: openjdk7
+  - scala: "2.12.0"
+    jdk: openjdk6
 
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -13,13 +13,12 @@ lazy val chart = (
     libraryDependencies ++= Specs2(scalaVersion.value).map(_ % "test"),
     libraryDependencies += itext % Optional,
     libraryDependencies += jfreesvg % Optional,
-    initialCommands in (Compile, consoleQuick) <<= initialCommands in Compile,
+    initialCommands in (Compile, consoleQuick) := (initialCommands in Compile).value,
     initialCommands in Compile in console += """
       import scalax.chart._
       import scalax.chart.api._
     """,
-    scalacOptions in (Compile, doc) <++= (baseDirectory) map { bd =>
-      Seq("-sourcepath", bd.getAbsolutePath, "-doc-source-url", docURL)
-    }
+    scalacOptions in (Compile, doc) ++=
+      Seq("-sourcepath", baseDirectory.value.getAbsolutePath, "-doc-source-url", docURL)
   )
 )

--- a/global.sbt
+++ b/global.sbt
@@ -1,5 +1,5 @@
 organization in ThisBuild := "com.github.wookietreiber"
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.0"
 
-crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.8", "2.12.0-M5")
+crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.8", "2.12.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,9 +9,9 @@ object Dependencies {
   val itext      = "com.itextpdf" % "itextpdf"   % "5.5.9"
 
   def Specs2(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2,12)) => List("org.specs2" %% "specs2-core" % "3.8.4")
-    case Some((2,11)) => List("org.specs2" %% "specs2-core" % "3.8.4")
-    case Some((2,10)) => List("org.specs2" %% "specs2-core" % "3.8.4")
+    case Some((2,12)) => List("org.specs2" %% "specs2-core" % "3.8.6")
+    case Some((2,11)) => List("org.specs2" %% "specs2-core" % "3.8.6")
+    case Some((2,10)) => List("org.specs2" %% "specs2-core" % "3.8.6")
     case _            => Nil
   }
 

--- a/project/publishing.scala
+++ b/project/publishing.scala
@@ -7,9 +7,9 @@ import Keys._
 object Publishing {
   val publishing = Seq (
     publishMavenStyle := true,
-    publishTo <<= version { (version: String) ⇒
+    publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (version.trim.endsWith("-SNAPSHOT"))
+      if (isSnapshot.value)
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases"  at nexus + "service/local/staging/deploy/maven2")


### PR DESCRIPTION
Updates Scala to 2.12.0 final and makes it the default Scala version. Also updates SBT to version 0.13.13, fixing the deprecation warnings that appeared.

With this merged, I hope you can publish a Scala 2.12 compatible version soon after :)
